### PR TITLE
make leaderboard show specific run

### DIFF
--- a/apis/prompts.py
+++ b/apis/prompts.py
@@ -115,21 +115,16 @@ def get_prompt_leaderboard(id, run_id):
     specificRunQuery = '''
     SELECT runs.run_id, path, runs.user_id, username, TIMESTAMPDIFF(MICROSECOND, runs.start_time, runs.end_time) AS run_time
     FROM runs
-    JOIN (
-            SELECT run_id
-            FROM runs
-            WHERE prompt_id=%s AND run_id=%s
-    ) latest
-    ON latest.run_id=runs.run_id
     LEFT JOIN users
     ON runs.user_id=users.user_id
+    WHERE runs.run_id=%s
     '''
 
     ordering = f'\nORDER BY run_time'
 
     if run_id:
         query = f'({query}) UNION ({specificRunQuery})'
-        args.extend([id, run_id])
+        args.append(run_id)
 
     query += ordering
     

--- a/apis/prompts.py
+++ b/apis/prompts.py
@@ -93,7 +93,7 @@ def set_prompt_publicity(id):
         return "Changed prompt to {}".format("public" if public else "ranked"), 200
 
 
-@prompt_api.get('/<id>/leaderboard', defaults={'run_id' : None})
+@prompt_api.get('/<id>/leaderboard/', defaults={'run_id' : None})
 @prompt_api.get('/<id>/leaderboard/<run_id>')
 def get_prompt_leaderboard(id, run_id):
     # TODO this could probably return details as well

--- a/static/js/prompt.js
+++ b/static/js/prompt.js
@@ -220,7 +220,7 @@ window.addEventListener("load", async function() {
     var response = await fetch("/api/prompts/" + prompt_id);
     const prompt = await response.json();
 
-    response = await fetch("/api/prompts/" + prompt_id + "/first_runs");
+    response = await fetch("/api/prompts/" + prompt_id + "/leaderboard/" + run_id);
     const runs = await response.json(); 
 
     generate_prompt(prompt);


### PR DESCRIPTION
fixes #56 

Now always shows run when given `run_id` of prompt. So this will work for anonymous runs as well as repeat runs from registered users 