### PR TITLE
Disable search shortcuts

### DIFF
--- a/static/js/play.js
+++ b/static/js/play.js
@@ -311,6 +311,12 @@ function checkForFind(e) {
     }
 }
 
+function disableFind(e) {
+    console.log(e);
+    if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && e.keyCode == 70)) { 
+        e.preventDefault();
+    }
+}
 
 window.addEventListener("load", async function() {
     const response = await fetch("/api/prompts/" + prompt_id);
@@ -343,11 +349,11 @@ window.onbeforeunload = function() {
 
 
 window.addEventListener("keydown", function(e) {
-    checkForFind(e);
+    disableFind(e);
 });
-window.addEventListener("keyup", function(e) {
-    checkForFind(e);
-});
+// window.addEventListener("keyup", function(e) {
+//     checkForFind(e);
+// });
 
 
 

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -10,7 +10,6 @@ var app = new Vue({
         started: false,
         gunShow: false,
         activeTip: "",
-        caught: false,
         path:[],
         finalTime:"",
         prompt_id: 0,
@@ -49,8 +48,6 @@ var endTime = 0;
 var run_id = -1;
 
 var keyMap = {};
-
-var ctrlfwarnings = false;
 
 function handleWikipediaLink(e) 
 {
@@ -285,8 +282,6 @@ function countdownOnLoad(start, end) {
             
 
             startTime = Date.now();
-            ctrlfwarnings = true;
-
         }
         if (distance < 700 && distance > 610) {
             app.$data.gunShow = true;
@@ -297,24 +292,11 @@ function countdownOnLoad(start, end) {
 
 }
 
-function checkForFind(e) {
-
-    console.log(e.code);
-    e = e || event;
-    keyMap[e.code] = e.type == 'keydown';
-    if (keyMap["KeyF"] && (keyMap["ControlLeft"] || keyMap["ControlRight"])) {
-        if (ctrlfwarnings == true) {
-
-            app.$data.finished = true;
-            app.$data.caught = true;
-        }
-    }
-}
-
 function disableFind(e) {
     console.log(e);
     if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && e.keyCode == 70)) { 
         e.preventDefault();
+        this.alert("WARNING: Attempt to Find in page. This will be recorded.")
     }
 }
 
@@ -351,10 +333,3 @@ window.onbeforeunload = function() {
 window.addEventListener("keydown", function(e) {
     disableFind(e);
 });
-// window.addEventListener("keyup", function(e) {
-//     checkForFind(e);
-// });
-
-
-
-

--- a/templates/play.html
+++ b/templates/play.html
@@ -70,11 +70,6 @@
         <div id="wikipedia-frame"></div>
     </div>
 
-    <div v-if="caught && started && !finished">
-        <p>STOP! You violated the law. Pay the court a fine or serve your sentence.</p>
-        <img src="{{url_for('static', filename='assets/stop.jpg')}}" width="700" style="margin-top: 40px;">
-    </div>
-
 </div>
 
 


### PR DESCRIPTION
- Instead of checking search shortcuts to catch potential cheaters, disabling it entirely for smoother game experience.
- Handling cases for more OS, keyboards, and browsers. Current check only works for Chrome, Safari and Ctrl keyboard layouts. 
- Tested with {OS: [Linux, Windows, MacOS], keyboards: [ctrl, meta], browsers: [Chrome, Safari, Firefox]}. NOTE: this is not robust to key remappings.
- Caveat: users will still be able to search the page by manually going into Settings -> Find. This is difficult to prevent. One potential solution is to obfuscate the entire page by randomly embedding invisible span elements.